### PR TITLE
Replace deprecated `GetClientAuthString` method.

### DIFF
--- a/thelpers/player.inc
+++ b/thelpers/player.inc
@@ -194,16 +194,16 @@ methodmap CBasePlayer < CBaseCombatCharacter
 
 	/**
 	 * Gets the Steam ID string of this player.
-	 *
+	 * @param authType		Auth id type and format to use.
 	 * @param buffer		The character buffer to copy the Steam ID to.
 	 * @param maxBuffer		The maximum size of the input buffer.
 	 * @param validate		Check Steam back-end validation status.
 	 *
 	 * @return		True on success, false otherwise.
 	*/
-	public bool GetSteamID( char[] buffer, int maxBuffer, bool validate = true )
+	public bool GetSteamID( AuthIdType authType, char[] buffer, int maxBuffer, bool validate = true )
 	{
-		return GetClientAuthString( this.Index, buffer, maxBuffer, validate );
+		return GetClientAuthId( this.Index, authType, buffer, maxBuffer, validate );
 	}
 
 	/**

--- a/thelpers/player.inc
+++ b/thelpers/player.inc
@@ -194,6 +194,7 @@ methodmap CBasePlayer < CBaseCombatCharacter
 
 	/**
 	 * Gets the Steam ID string of this player.
+	 *
 	 * @param authType		Auth id type and format to use.
 	 * @param buffer		The character buffer to copy the Steam ID to.
 	 * @param maxBuffer		The maximum size of the input buffer.


### PR DESCRIPTION
The method used in player.inc to retrieve steam auth string is deprecated, replaced with the new method.