### PR TITLE
Fixed small typo

### DIFF
--- a/thelpers/css/player.inc
+++ b/thelpers/css/player.inc
@@ -41,7 +41,7 @@ methodmap CCSPlayer __nullable__ < CBasePlayer
 	 *
 	 * @return		The number of non-null bytes written to output buffer.
 	*/
-	public int GetClanTag( char buffer[], int maxBuffer )
+	public int GetClanTag( char[] buffer, int maxBuffer )
 	{
 		return CS_GetClientClanTag( this.Index, buffer, maxBuffer );
 	}


### PR DESCRIPTION
Also I get this:

SourcePawn Compiler 1.8.0-dev+5699
Copyright (c) 1997-2006 ITB CompuPhase
Copyright (c) 2004-2015 AlliedModders LLC

...\sourcemod\scripting\include\thelpers/econ/entity.inc(76) : warning 213: tag mismatch
...\sourcemod\scripting\include\thelpers/econ/entity.inc(91) : warning 213: tag mismatch

2 Warnings.

Which should not be the case I think, as the lines use 'view_as'. Seems like it is ignored?
